### PR TITLE
Fix / !const support by updating Structurizr CLI to v2025.05.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #   - about ENTRYPOINT: GitHub Actions recommend using an absolute path for the entrypoint. 
 
 # Builder stage
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21.0.7_6-jre-noble as builder
 
 # Install dependencies
 RUN apt-get update && \
@@ -25,7 +25,7 @@ RUN mkdir /structurizr-cli && \
     rm structurizr-cli-*.zip
 
 ### Final image ###
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21.0.7_6-jre-noble
 
 # Install dependencies and clean up
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This Docker image does exactly what the `structurizr/cli` image does, but with the added configuration that it allows a run within Github Actions. It includes additional tools such as Git, jq, and PlantUML, as well as Graphviz and `structurizr.sh` (v1.35.0), making this image ideal for advanced diagram generation and version control in Structurizr projects including documentation-as-code. The image is automatically built and published using a GitHub Actions workflow. For now this image depends on manually updating the CLI zip file which is downloaded from the [official release website](https://github.com/structurizr/cli/releases). 
+This Docker image does exactly what the `structurizr/cli` image does, but with the added configuration that it allows a run within Github Actions. It includes additional tools such as Git, jq, and PlantUML, as well as Graphviz and `structurizr.sh` (v2025.05.28), making this image ideal for advanced diagram generation and version control in Structurizr projects including documentation-as-code. The image is automatically built and published using a GitHub Actions workflow. For now this image depends on manually updating the CLI zip file which is downloaded from the [official release website](https://github.com/structurizr/cli/releases). 
 
 ## Why do I need this?
 


### PR DESCRIPTION

  ## Summary

  This PR updates the Structurizr CLI from v1.35.0 to v2025.05.28 to fix the `!const` directive parsing issue.


  ## Changes

  - Updated Structurizr CLI binary from v1.35.0 to v2025.05.28
  - Upgraded Java runtime from Eclipse Temurin 17 to 21 (required by newer CLI version)
  - Updated README to reflect new CLI version

  ## Fixes

  Fixes #1 - Adds support for `!const` directive in workspace.dsl files. The newer CLI version includes the parser updates needed to handle constant declarations properly.

  ## Testing

  The updated CLI now correctly parses DSL files containing `!const` declarations without throwing `StructurizrDslParserException`.

## Acknowledgements

- [x] I have followed the guidelines in the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation, and I have updated it accordingly.
